### PR TITLE
disable the parcel cache for local builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "parcel public/index.html",
-    "start-advanced-mode": "parcel advanced/public/index.html",
+    "start": "parcel public/index.html --no-cache",
+    "start-advanced-mode": "parcel advanced/public/index.html --no-cache",
     "server": "node advanced/src/server.mjs"
   },
   "keywords": [],


### PR DESCRIPTION
Parcel cache might not pick up on the file changes and build properly which can cause your embed to look as though you made no changes/they didn't work properly. 